### PR TITLE
Add mongodb for future GTFS import

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,17 @@
+# Run serviceoffer container alone
+
+docker build . -t serviceoffer
+docker run -p 4000:4000 serviceoffer
+
+## Test
+
+<http://localhost:4000/graphql>
+
+# Run serviceoffer completly
+
+docker-compose build
+docker-compose up
+
+## Test 
+
+MongoDB admin: <http://localhost:8082/>

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,30 @@
+version: "2"
+
+services:
+  serviceoffer:
+    container_name: serviceoffer
+    restart: always
+    build: .
+    ports:
+      - "4000:4000"
+    links:
+      - mongo
+
+  mongo:
+    container_name: graphqlmongo
+    image: mongo
+    volumes:
+      - ./data:/data/db
+    ports:
+      - "27017:27017"
+
+  admin-mongo:
+    image: 0x59/admin-mongo:latest
+    ports:
+      - "8082:8082"
+    environment:
+      - PORT=8082
+      - CONN_NAME=mongo
+      - DB_HOST=mongo
+    links:
+      - mongo

--- a/dockerfile
+++ b/dockerfile
@@ -1,0 +1,10 @@
+FROM node:latest
+
+WORKDIR /usr/src/app/serviceoffer
+
+COPY ./package.json /usr/src/app/serviceoffer
+
+RUN npm install
+COPY . /usr/src/app/serviceoffer
+EXPOSE 4000
+CMD npm run dev


### PR DESCRIPTION
Support for docker-compose addded in order to run multiple containers
such as mongodb and mongodb admin console.